### PR TITLE
fix: url-encode push credentials and add .gitignore

### DIFF
--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -48,8 +48,16 @@ jobs:
       - name: Create repo if not exists
         if: ${{ steps.exist.outputs.repo == '0' }}
         run: aws codecommit create-repository --repository-name $repoName
+      - name: Encode credentials
+        run: |
+          encoded_user=$(python3 -c 'import urllib.parse,sys; print(urllib.parse.quote(sys.argv[1],safe=""))' "$user")
+          encoded_password=$(python3 -c 'import urllib.parse,sys; print(urllib.parse.quote(sys.argv[1],safe=""))' "$password")
+          echo "::add-mask::$encoded_user"
+          echo "::add-mask::$encoded_password"
+          echo "encoded_user=$encoded_user" >> $GITHUB_ENV
+          echo "encoded_password=$encoded_password" >> $GITHUB_ENV
       - name: push
         run: |
           git clone --mirror $source $repoName
           cd $repoName
-          git push -f https://$user:$password@git-codecommit.us-east-1.amazonaws.com/v1/repos/$repoName --all
+          git push -f https://$encoded_user:$encoded_password@git-codecommit.us-east-1.amazonaws.com/v1/repos/$repoName --all

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+CLAUDE.md


### PR DESCRIPTION
Add a workflow step to URL-encode and mask the user/password before using them in the git push URL, storing encoded values in GITHUB_ENV and updating the push command to use them to avoid issues with special characters. Also add .gitignore to ignore CLAUDE.md.